### PR TITLE
Modify Spotify.prototype.sendPong to use custom pingPongServerUrl

### DIFF
--- a/lib/spotify.js
+++ b/lib/spotify.js
@@ -73,7 +73,7 @@ Spotify.login = function (un, pw, fn) {
  * @api public
  */
 
-function Spotify () {
+function Spotify (pingPongServerUrl) {
   if (!(this instanceof Spotify)) return new Spotify();
   EventEmitter.call(this);
 
@@ -87,6 +87,7 @@ function Spotify () {
   this.authUrl = '/xhr/json/auth.php';
   this.landingUrl = '/';
   this.userAgent = 'Mozilla/5.0 (Chrome/13.37 compatible-ish) spotify-web/' + pkg.version;
+  this.pingPongServerUrl = pingPongServerUrl;
 
   // base URLs for Image files like album artwork, artist prfiles, etc.
   // these values taken from "spotify.web.client.js"
@@ -475,14 +476,17 @@ Spotify.prototype._onworkdone = function (err, res) {
 
 Spotify.prototype.sendPong = function(ping) {
   this.agent
-  .get('http://ping-pong.spotify.nodestuff.net/' + ping.split(" ").join("-"))
+  .get(this.pingPongServerUrl + '?ping=' + ping)
   .set({ 'User-Agent': this.userAgent })
+  .type("json")
   .end(function (err, res) {
     if (err) return this.emit('error', err);
 
-    if (res.body.status == 100) {
-      pong = res.body.pong.split("-").join(" ");
+    if (res.status === 200) {
+      pong = res.text;
       this.sendCommand('sp/pong_flash2', [ pong ]);
+    } else {
+      this.emit('error', new Error('ping_pong_failed'));
     }
   }.bind(this));
 };


### PR DESCRIPTION
Since we re-forked the repo, we need to re-apply the changes made to the previous fork.

We start off by customizing the `sendPong` function to use our custom PingPong server.

This code has already been reviewed.
