### PR TITLE
Modify rootlist call to fetch private playlists

### DIFF
--- a/lib/spotify.js
+++ b/lib/spotify.js
@@ -830,6 +830,8 @@ Spotify.prototype.starred = function (user, from, length, fn) {
  */
 
 Spotify.prototype.rootlist = function (user, from, length, fn) {
+  var endpoint = 'publishedrootlist';
+
   // argument surgery
   if ('function' == typeof user) {
     fn = user;
@@ -841,14 +843,17 @@ Spotify.prototype.rootlist = function (user, from, length, fn) {
     fn = length;
     length = null;
   }
-  if (null == user) user = this.username;
+  if (null == user) {
+    user = this.username;
+    endpoint = 'rootlist';
+  }
   if (null == from) from = 0;
   if (null == length) length = 100;
 
-  debug('rootlist(%j, %j, %j)', user, from, length);
+  debug('publishedrootlist(%j, %j, %j)', user, from, length);
 
   var self = this;
-  var hm = 'hm://playlist/user/' + user + '/publishedrootlist?from=' + from + '&length=' + length;
+  var hm = 'hm://playlist/user/' + user + '/' + endpoint + '?from=' + from + '&length=' + length;
 
   this.sendProtobufRequest({
     header: {


### PR DESCRIPTION
Last adjustment to bring back to the new fork

We modify the `rootlist` function to call the `rootlist` endpoint instead of `publishedrootlist` when no username is provided. This allows us to fetch the current user's private playlists as well as public playlists.

Already reviewed as well
